### PR TITLE
Add search for tokens

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func parseStrings(document *etree.Document, googleURL interface{}) {
 
 		// Some keys that I have found in loads of strings.xml and they have nothing important
 		// so just filter those out.
-		if strings.Contains(strings.ToLower(strValues), "api") && str.Text() != "" && strings.Contains(strings.ToLower(strValues), "key") {
+		if strings.Contains(strings.ToLower(strValues), "api") && str.Text() != "" && strings.Contains(strings.ToLower(strValues), "key") && strings.Contains(strings.ToLower(strValues), "tokens") {
 			if strValues == "abc_capital_off" || strValues == "abc_capital_on" || strValues == "currentApiLevel" {
 				continue
 			}


### PR DESCRIPTION
Now it will also catch all the strings that have `tokens` in it.